### PR TITLE
exclude security_txt from no-entrypoint builds

### DIFF
--- a/program/programs/solana-place/src/lib.rs
+++ b/program/programs/solana-place/src/lib.rs
@@ -32,6 +32,7 @@ pub mod solana_place {
 
 }
 
+#[cfg(not(feature = "no-entrypoint"))]
 security_txt! {
     name: "Place | Solana",
     project_url: "https://solana-place.com/",


### PR DESCRIPTION
The usage of `solana-security-txt` previously recommended in the official usage guide has an issue:

When multiple projects within a build, including dependencies, define a security-txt, the build fails.

To avoid this issue, library authors - including projects that *might* be used as a library by others in the future - should exclude the `security_txt` macro during `no-entrypoint` builds.

Feel free to read up on the details in [the issue on the security-txt repository](https://github.com/neodyme-labs/solana-security-txt/issues/11).

The [official usage guide](https://github.com/neodyme-labs/solana-security-txt#usage) has also been updated. This PR includes the recommended changes.
